### PR TITLE
Update chart release notes for #4304

### DIFF
--- a/github/patternfly/patternfly-react/pull_requests/breaking-change-notes.md
+++ b/github/patternfly/patternfly-react/pull_requests/breaking-change-notes.md
@@ -230,8 +230,11 @@ Additional issues: https://github.com/patternfly/patternfly/issues/2725
 ## chore(table): update types in table [(#3296)](https://github.com/patternfly/patternfly-react/pull/3296)
 - Change type of `onSelect` in Table from `(event: React.ChangeEvent<HTMLInputElement>) => void` to `(event: React.FormEvent<HTMLInputElement>) => void`
 
+## fix(charts): Update types to match latest Victory packages [(#4304)](https://github.com/patternfly/patternfly-react/pull/4304)
+- Updated Victory to package versions to 34.3.8
+
 ## fix(charts): Bump Victory packages [(#3974)](https://github.com/patternfly/patternfly-react/pull/3974)
-- Updated Victory to package versions to 34.x
+- Updated Victory to package versions to 34.1.3
 
 ## fix(charts): Update react-charts types [(#4138)](https://github.com/patternfly/patternfly-react/pull/4138)
 - Removed the @types/victory dependency and updated the PatternFly charts to use the types introduced with Victory 34.x

--- a/github/patternfly/patternfly-react/pull_requests/pretty-notes.md
+++ b/github/patternfly/patternfly-react/pull_requests/pretty-notes.md
@@ -285,7 +285,8 @@ Hey Fliers, we've been busy for the past 9 weeks keeping up with changes to Patt
   - Renamed prop `text` to `content`. The type of the prop has been changed to `React.ReactNode` to allow for flexibility. [(#4063)](https://github.com/patternfly/patternfly-react/pull/4063)
 
 ### React charts
-- Updated Victory to package versions to 34.x. [(#3974)](https://github.com/patternfly/patternfly-react/pull/3974)
+- Update types to match latest Victory 34.3.8 packages. [(#4304)](https://github.com/patternfly/patternfly-react/pull/4304)
+- Updated Victory to package versions to 34.1.3. [(#3974)](https://github.com/patternfly/patternfly-react/pull/3974)
 - Removed the `@types/victory` dependency and updated the PatternFly charts to use the types introduced with Victory 34.x. [(#4138)](https://github.com/patternfly/patternfly-react/pull/4138)
 - Updated label prop types to sync with Victory 34.x. [(#4152)](https://github.com/patternfly/patternfly-react/pull/4152)
 - Use `containerComponent={<VictoryZoomComponent />}` with Chart instead of `allowZoom`. [(#4278)](https://github.com/patternfly/patternfly-react/pull/4278)


### PR DESCRIPTION
Updated our chart types to match Victory 34.3.8.

See https://github.com/patternfly/patternfly-react/pull/4304